### PR TITLE
Ensuring that valid json is written when using pagination and single string selectors

### DIFF
--- a/lib/x-ray.js
+++ b/lib/x-ray.js
@@ -237,6 +237,7 @@ Xray.prototype.write = function(file) {
   function next(json) {
     debug('writing to the stream');
     var str = 'string' == typeof json ? json : JSON.stringify(json, true, 2)
+    var str = (!haspagination && 'string' == typeof json) ? json : JSON.stringify(json, true, 2)
 
     // handle arrays
     if (isarray || haspagination) {

--- a/test/fixtures/paginate-string.js
+++ b/test/fixtures/paginate-string.js
@@ -1,0 +1,10 @@
+var assert = require('assert');
+
+exports.input = '.pagehead strong';
+
+exports.expected = function(arr) {
+  assert(arr.length === 2, 'array length (' + arr.length + ') incorrect');
+  arr.forEach(function(item) {
+    assert.equal(item, '(Matthew Mueller)');
+  });
+}

--- a/test/x-ray.js
+++ b/test/x-ray.js
@@ -135,6 +135,23 @@ describe('x-ray', function() {
       })
   });
 
+  it('should stream paginated strings to stdout', function(done) {
+    var fixture = get('paginate-string');
+    var restore = stdout();
+
+    xray('https://github.com/stars/matthewmueller')
+      .select(fixture.input)
+      .paginate('.pagination a:last-child[href]')
+      .limit(2)
+      .write(process.stdout)
+      .once('error', done)
+      .once('close', function() {
+        var arr = JSON.parse(restore());
+        fixture.expected(arr);
+        done();
+      })
+  });
+
   it('should stream objects to stdout', function(done) {
     var restore = stdout();
     xray('http://google.com')


### PR DESCRIPTION
Updates the output written by .write() under the following conditions:
1. Pagination enabled
2. A select() that will return a single string

Current behavior will write something like:

```
[
   Page 1 Content
   ,
   Page 2 Content
]
```

This PR changes that to:

```
[
   "Page 1 Content"
   ,
   "Page 2 Content"
]
```
