### PR TITLE
Prevent infinite loops while paging certain sites

### DIFF
--- a/lib/x-ray.js
+++ b/lib/x-ray.js
@@ -292,6 +292,7 @@ Xray.prototype.traverse = function(fn, done) {
   var format = this._format;
   var url = this.url;
   var self = this;
+  var previousUrl = url;
 
   // initial request
   debug('initial request: %s', url);
@@ -315,10 +316,13 @@ Xray.prototype.traverse = function(fn, done) {
       return fn(json), done(null);
     }
 
-    if (!href) {
+    // check to see if there is a next page, or that the next page is the same as the last
+    if (!href || href === previousUrl) {
       debug('no next page, finishing up.')
       return fn(json), done(null);
     }
+
+    previousUrl = href;
 
     // callback and continue
     fn(json);


### PR DESCRIPTION
On some sites (ex: www.asofterworld.com), when you reach the last page, the "next" link will still be present on the page, pointing to the current url.  

Since that link is present, x-ray will get it's content, and the same next url, causing an infinite loop.

This PR detects whether the next url to visit is the same as the current url before trying to continue.

I wasn't sure if x-ray supported javascript based pagination, so this may need to be hidden behind a flag..
