### PR TITLE
Add "abort" callback to allow for dynamically ending pagination based on scrape results

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -132,6 +132,14 @@ Select a `url` from a `selector` and visit that page.
 
 Limit the amount of pagination to `n` requests.
 
+### xray.abort(validator)
+
+Abort pagination if `validator` function returns `true`.
+The `validator` function receives two arguments:
+
+- `result`: The scrape result object for the current page.
+- `nextUrl`: The URL of the next page to scrape.
+
 ### xray.delay(from, [to])
 
 Delay the next request between `from` and `to` milliseconds.

--- a/index.js
+++ b/index.js
@@ -17,12 +17,13 @@ var walk = require('./lib/walk')
 var fs = require('fs')
 
 var CONST = {
-  CRAWLER_METHODS: ['concurrency', 'throttle', 'timeout', 'driver', 'delay', 'limit'],
+  CRAWLER_METHODS: ['concurrency', 'throttle', 'timeout', 'driver', 'delay', 'limit', 'abort'],
   INIT_STATE: {
     stream: false,
     concurrency: Infinity,
     paginate: false,
-    limit: Infinity
+    limit: Infinity,
+    abort: false
   }
 }
 
@@ -122,6 +123,12 @@ function Xray (options) {
             return fn(null, pages)
           }
 
+          if (state.abort && state.abort(obj, url)) {
+            debug('abort check passed, ending')
+            stream(obj, true)
+            return fn(null, pages)
+          }
+
           stream(obj)
 
           // debug
@@ -139,6 +146,12 @@ function Xray (options) {
         }
       }
 
+      return node
+    }
+
+    node.abort = function (validator) {
+      if (!arguments.length) return state.abort
+      state.abort = validator
       return node
     }
 

--- a/test/xray_spec.js
+++ b/test/xray_spec.js
@@ -16,9 +16,13 @@ var Xray = require('..')
 
 /**
  * URL
+ *
+ * We can be reasonably certain the issues list with that sorting will stay static,
+ * since it is sorted by created date.
  */
 
 var url = 'http://lapwinglabs.github.io/static/'
+var pagedUrl = 'https://github.com/lapwinglabs/x-ray/issues?q=is%3Aissue%20sort%3Acreated-asc%20'
 
 /**
  * Tests
@@ -284,6 +288,72 @@ describe('Xray basics', function () {
         assert.equal(true, isUrl(item.image))
       })
       done()
+    })
+  })
+
+  describe.only('test', function () {
+    it('should work with pagination & abort function checking returned object', function (done) {
+      this.timeout(10000)
+      var x = Xray()
+
+      var xray = x(pagedUrl, 'li.js-issue-row', [{
+        id: '@id',
+        title: 'a.h4'
+      }])
+        .paginate('.next_page@href')
+        .limit(3)
+        .abort(function (result) {
+          var i = 0
+
+          // Issue 40 is on page 2 of our result set
+          for (; i < result.length; i++) {
+            if (result[i].id === 'issue_40') return true
+          }
+
+          return false
+        })
+
+      xray(function (err, arr) {
+        if (err) return done(err)
+        // 25 results per page
+        assert.equal(50, arr.length)
+
+        arr.forEach(function (item) {
+          assert(item.id.length)
+          assert(item.title.length)
+        })
+        done()
+      })
+    })
+
+    it('should work with pagination & abort function checking next URL', function (done) {
+      this.timeout(10000)
+      var x = Xray()
+
+      var xray = x(pagedUrl, 'li.js-issue-row', [{
+        id: '@id',
+        title: 'a.h4'
+      }])
+        .paginate('.next_page@href')
+        .limit(3)
+        .abort(function (result, url) {
+          // Break after page 2
+          if (url.indexOf('page=3') >= 0) return true
+
+          return false
+        })
+
+      xray(function (err, arr) {
+        if (err) return done(err)
+        // 25 results per page
+        assert.equal(50, arr.length)
+
+        arr.forEach(function (item) {
+          assert(item.id.length)
+          assert(item.title.length)
+        })
+        done()
+      })
     })
   })
 

--- a/test/xray_spec.js
+++ b/test/xray_spec.js
@@ -291,69 +291,67 @@ describe('Xray basics', function () {
     })
   })
 
-  describe.only('test', function () {
-    it('should work with pagination & abort function checking returned object', function (done) {
-      this.timeout(10000)
-      var x = Xray()
+  it('should work with pagination & abort function checking returned object', function (done) {
+    this.timeout(10000)
+    var x = Xray()
 
-      var xray = x(pagedUrl, 'li.js-issue-row', [{
-        id: '@id',
-        title: 'a.h4'
-      }])
-        .paginate('.next_page@href')
-        .limit(3)
-        .abort(function (result) {
-          var i = 0
+    var xray = x(pagedUrl, 'li.js-issue-row', [{
+      id: '@id',
+      title: 'a.h4'
+    }])
+      .paginate('.next_page@href')
+      .limit(3)
+      .abort(function (result) {
+        var i = 0
 
-          // Issue 40 is on page 2 of our result set
-          for (; i < result.length; i++) {
-            if (result[i].id === 'issue_40') return true
-          }
+        // Issue 40 is on page 2 of our result set
+        for (; i < result.length; i++) {
+          if (result[i].id === 'issue_40') return true
+        }
 
-          return false
-        })
-
-      xray(function (err, arr) {
-        if (err) return done(err)
-        // 25 results per page
-        assert.equal(50, arr.length)
-
-        arr.forEach(function (item) {
-          assert(item.id.length)
-          assert(item.title.length)
-        })
-        done()
+        return false
       })
+
+    xray(function (err, arr) {
+      if (err) return done(err)
+      // 25 results per page
+      assert.equal(50, arr.length)
+
+      arr.forEach(function (item) {
+        assert(item.id.length)
+        assert(item.title.length)
+      })
+      done()
     })
+  })
 
-    it('should work with pagination & abort function checking next URL', function (done) {
-      this.timeout(10000)
-      var x = Xray()
+  it('should work with pagination & abort function checking next URL', function (done) {
+    this.timeout(10000)
+    var x = Xray()
 
-      var xray = x(pagedUrl, 'li.js-issue-row', [{
-        id: '@id',
-        title: 'a.h4'
-      }])
-        .paginate('.next_page@href')
-        .limit(3)
-        .abort(function (result, url) {
-          // Break after page 2
-          if (url.indexOf('page=3') >= 0) return true
+    var xray = x(pagedUrl, 'li.js-issue-row', [{
+      id: '@id',
+      title: 'a.h4'
+    }])
+      .paginate('.next_page@href')
+      .limit(3)
+      .abort(function (result, url) {
+        // Break after page 2
+        if (url.indexOf('page=3') >= 0) return true
 
-          return false
-        })
-
-      xray(function (err, arr) {
-        if (err) return done(err)
-        // 25 results per page
-        assert.equal(50, arr.length)
-
-        arr.forEach(function (item) {
-          assert(item.id.length)
-          assert(item.title.length)
-        })
-        done()
+        return false
       })
+
+    xray(function (err, arr) {
+      if (err) return done(err)
+      // 25 results per page
+      assert.equal(50, arr.length)
+
+      arr.forEach(function (item) {
+        assert(item.id.length)
+        assert(item.title.length)
+      })
+      done()
     })
   })
 


### PR DESCRIPTION
### Description

This PR adds an "abort" function to the x-ray API which allows supplying a callback function which receives scrape results and the next url.

If this callback returns `true` the pagination ends and the results up to this point are returned. This allows for, for example, scraping a paginated website and stopping the scrape based on timestamps included in content. This can reduce the amount of pages hit, since we can abort scrapes immediately once the requisite data is located.

Also, I could not locate the `AUTHORS` file referenced in the PR checklist.

### Checklist

- [X] Code compiles correctly
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing
- [X] Extended the README / documentation, if necessary
- [?] Added myself / the copyright holder to the AUTHORS file