### PR TITLE
Add Promise for `xray.then()`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -124,6 +124,25 @@ Stream the results to a `path`.
 
 If no path is provided, then the behavior is the same as [.stream()](#xraystream).
 
+### xray.then(cb)
+
+Constructs a `Promise` object and invoke its `then` function with a callback `cb`. Be sure to invoke `then()` at the last step of xray method chaining, since the other methods are not promisified.
+
+```js
+x('https://dribbble.com', 'li.group', [{
+  title: '.dribbble-img strong',
+  image: '.dribbble-img [data-src]@data-src',
+}])
+  .paginate('.next_page@href')
+  .limit(3)
+  .then(function (res) {
+    console.log(res[0]) // prints first result
+  })
+  .catch(function (err) {
+    console.log(err) // handle error in promise
+  })
+```
+
 ### xray.paginate(selector)
 
 Select a `url` from a `selector` and visit that page.

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var objectAssign = require('./lib/util').objectAssign
+var streamToPromise = require('./lib/promisify')
 var compact = require('./lib/util').compact
 var isArray = require('./lib/util').isArray
 var absolutes = require('./lib/absolutes')
@@ -166,6 +167,10 @@ function Xray (options) {
       state.stream = fs.createWriteStream(path)
       streamHelper.waitCb(state.stream, node)
       return state.stream
+    }
+
+    node.then = function (cb) {
+      return streamToPromise(node.stream()).then(cb)
     }
 
     return node

--- a/lib/promisify.js
+++ b/lib/promisify.js
@@ -1,0 +1,31 @@
+/**
+ * Module Dependencies
+ */
+
+var Promise = require('bluebird')
+var sts = require('stream-to-string')
+
+/**
+ * Export `params`
+ */
+
+module.exports = streamToPromise
+
+/**
+ * Convert a readStream from xray.stream() into
+ * a Promise resolved with written string
+ *
+ * @param {Stream} strem
+ * @return {Promise}
+ */
+function streamToPromise (stream) {
+  return new Promise(function (resolve, reject) {
+    sts(stream, function (err, resStr) {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(JSON.parse(resStr))
+      }
+    })
+  })
+}

--- a/lib/promisify.js
+++ b/lib/promisify.js
@@ -24,7 +24,11 @@ function streamToPromise (stream) {
       if (err) {
         reject(err)
       } else {
-        resolve(JSON.parse(resStr))
+        try {
+          resolve(JSON.parse(resStr))
+        } catch (e) {
+          reject(e)
+        }
       }
     })
   })

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   ],
   "dependencies": {
     "batch": "~0.5.2",
+    "bluebird": "^3.4.7",
     "chalk": "~1.1.1",
     "cheerio": "~0.20.0",
     "debug": "~2.2.0",
@@ -38,6 +39,7 @@
     "is-url": "~1.2.0",
     "isobject": "~2.0.0",
     "object-assign": "~4.0.1",
+    "stream-to-string": "^1.1.0",
     "x-ray-crawler": "~2.0.1",
     "x-ray-parse": "~1.0.1"
   },

--- a/test/xray_spec.js
+++ b/test/xray_spec.js
@@ -399,4 +399,26 @@ describe('Xray basics', function () {
       })
     })
   })
+
+  describe('.then(cb)', function () {
+    it('should Promisify and pass cb to .then(cb)', function (done) {
+      var html = '<ul class="tags"><li>a</li><li>b</li><li>c</li></ul><ul class="tags"><li>d</li><li>e</li></ul>'
+      var $ = cheerio.load(html)
+      var x = Xray()
+
+      var xray = x($, '.tags', [['li']])
+
+      xray
+        .then(function (arr) {
+          assert(arr[0].length === 3)
+          assert(arr[0][0] === 'a')
+          assert(arr[0][1] === 'b')
+          assert(arr[0][2] === 'c')
+          assert(arr[1].length === 2)
+          assert(arr[1][0] === 'd')
+          assert(arr[1][1] === 'e')
+          done()
+        })
+    })
+  })
 })


### PR DESCRIPTION
### Add Promise for `xray.then()`

This solves the feature request for a promise, #62 

- Create a new method `node.then(cb)`. Use the `node.stream()` method, create a promise from the stream, then invoke the `then()` with the callback `cb`.
- add test
- update documentation

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file