### PR TITLE
fixing path for require() for XRay and a typo in path.resolve

### DIFF
--- a/examples/selector/index.js
+++ b/examples/selector/index.js
@@ -1,7 +1,7 @@
 var path = require('path')
 var read = require('fs').readFileSync
-var html = read(path.resovlve(__dirname, 'index.html'))
-var Xray = require('..')
+var html = read(path.resolve(__dirname, 'index.html'))
+var Xray = require('../..')
 var x = Xray()
 
 x(html, 'h2')(console.log)


### PR DESCRIPTION
examples/selector/example was broken - two typos.
