### PR TITLE
If paginate is a function, call the function to get the url.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -134,7 +134,7 @@ If no path is provided, then the behavior is the same as [.stream()](#xraystream
 
 ### xray.paginate(selector)
 
-Select a `url` from a `selector` and visit that page.
+Select a `url` from a `selector` and visit that page. Alternatively accepts a function which should return the URL of the next page to visit.
 
 ### xray.limit(n)
 

--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ function Xray (options) {
             return fn(null, pages)
           }
 
-          var url = resolve($, false, paginate, filters)
+          var url = (typeof(paginate) == 'function') ? paginate() : resolve($, false, paginate, filters);
           debug('paginate(%j) => %j', paginate, url)
 
           if (!isUrl(url)) {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     {
       "name": "Fabien Franzen",
       "email": "info@atelierfabien.be"
+    },
+    {
+      "name": "nzhenry"
     }
   ],
   "repository": {

--- a/test/xray_spec.js
+++ b/test/xray_spec.js
@@ -287,6 +287,29 @@ describe('Xray basics', function () {
     })
   })
 
+  it('should work with paginate function', function (done) {
+    this.timeout(10000)
+    var x = Xray()
+
+    var xray = x('https://blog.ycombinator.com/', '.post', [{
+      title: 'h1 a',
+      link: '.article-title@href'
+    }])
+      .paginate(function(){"https://blog.ycombinator.com/page/2/"})
+      .limit(2)
+
+    xray(function (err, arr) {
+      if (err) return done(err)
+      assert(arr.length, 'array should have a length')
+
+      arr.forEach(function (item) {
+        assert(item.title.length)
+        assert.equal(true, isUrl(item.link))
+      })
+      done()
+    })
+  })
+
   it('should not call function twice when reaching the last page', function (done) {
     this.timeout(10000)
     setTimeout(done, 9000)


### PR DESCRIPTION
Else stick with the default behaviour and attempt to resolve the css selector.

### Description

Addresses the following issues:
- https://github.com/matthewmueller/x-ray/issues/54
- https://github.com/matthewmueller/x-ray/issues/122
- https://github.com/matthewmueller/x-ray/issues/242

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTHORS file