### PR TITLE
forcing version of is-url

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "cheerio": "~0.20.0",
     "debug": "~2.2.0",
     "enstore": "~1.0.1",
-    "is-url": "~1.2.0",
+    "is-url": "1.2.2",
     "isobject": "~2.0.0",
     "object-assign": "~4.0.1",
     "stream-to-string": "^1.1.0",


### PR DESCRIPTION
### Description

I have taken off the ~ character for your is-url dependency. They pushed an update for the first time in two years and it broke parsing when passing in an HTML string as the first argument to an x-ray function. This forces the version of that dependency to the last stable commit.

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file