### PR TITLE
Fix debug dependency vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "bluebird": "^3.4.7",
     "chalk": "~1.1.1",
     "cheerio": "~0.20.0",
-    "debug": "~2.2.0",
+    "debug": ">=2.6.9",
     "enstore": "~1.0.1",
     "is-url": "~1.2.0",
     "isobject": "~2.0.0",


### PR DESCRIPTION
### Description

#### CVE-2017-16137 [More information](https://nvd.nist.gov/vuln/detail/CVE-2017-16137)

__Vulnerable versions__: `< 2.6.9`
__Patched version__: `2.6.9`

The debug module is vulnerable to regular expression denial of service when untrusted user input is passed into the o formatter. It takes around 50k characters to block for 2 seconds making this a low severity issue.

---

> Possibly related: #316 
