### PR TITLE
Fix array stream to account for empty arrays

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -16,6 +16,7 @@ module.exports = {
       var json = isArray(data) ? string.slice(1, -1) : string
       var empty = json.trim() === ''
 
+      if (first && empty && !end) return
       if (first) { stream.write('[\n') }
       if (!first && !empty) { stream.write(',') }
 

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -5,28 +5,27 @@ module.exports = {
    * Streaming array helper
    *
    * @param {Stream} data (optional)
+   * @return {Function}
    */
   array: function stream_array (stream) {
     if (!stream) return function () {}
     var first = true
 
     return function _stream_array (data, end) {
-      var json = JSON.stringify(data, true, 2)
+      var string = JSON.stringify(data, true, 2)
+      var json = isArray(data) ? string.slice(1, -1) : string
+      var empty = json.trim() === ''
 
-      if (first) {
-        stream.write('[\n')
-        first = false
-      }
-
-      if (isArray(data)) {
-        json = json.slice(1, -1)
-      }
+      if (first) { stream.write('[\n') }
+      if (!first && !empty) { stream.write(',') }
 
       if (end) {
         stream.end(json + ']')
       } else {
-        stream.write(json + ',')
+        stream.write(json)
       }
+
+      first = false
     }
   },
 

--- a/test/stream_spec.js
+++ b/test/stream_spec.js
@@ -1,0 +1,87 @@
+/* global it describe */
+
+/**
+ * Module Dependencies
+ */
+
+var assert = require('assert')
+var EventEmitter = require('events')
+var streamHelper = require('../lib/stream')
+
+function createStream () {
+  var instance = new EventEmitter()
+  instance._data = ''
+  instance._open = true
+  instance.on('write', function (chunk) { instance._data += chunk })
+  instance.once('end', function () { instance._open = false })
+
+  instance.write = function write (chunk) { instance.emit('write', String(chunk) || '') }
+  instance.error = function error (err) { instance.emit('error', err) }
+  instance.end = function end (chunk) {
+    if (!instance._open) return
+    instance.emit('write', chunk)
+    instance.emit('end')
+  }
+
+  return instance
+}
+
+function getSessionResult () {
+  var events = Array.prototype.slice.call(arguments)
+  var stream = createStream()
+  var helper = streamHelper.array(stream)
+  events.forEach(function (data, index) { helper(data, index === events.length - 1) })
+  while (stream._open) { /* wait for stream to close */ }
+  return JSON.stringify(JSON.parse(stream._data))
+}
+
+/**
+ * Tests
+ */
+
+describe('stream.array helper', function () {
+  it('accepts non-empty arrays', function () {
+    var result = getSessionResult([1, 2], [3])
+    assert.equal(result, '[1,2,3]')
+  })
+  it('accepts one non-empty array', function () {
+    var result = getSessionResult([1])
+    assert.equal(result, '[1]')
+  })
+  it('accepts one empty array', function () {
+    var result = getSessionResult([])
+    assert.equal(result, '[]')
+  })
+  it('accepts one single value', function () {
+    var result = getSessionResult(1)
+    assert.equal(result, '[1]')
+  })
+  it('accepts multiple values', function () {
+    var result = getSessionResult(1, 2, 3)
+    assert.equal(result, '[1,2,3]')
+  })
+  it('accepts one empty array at the end', function () {
+    var result = getSessionResult([1, 2], [3], [])
+    assert.equal(result, '[1,2,3]')
+  })
+  it('accepts multiple empty arrays', function () {
+    var result = getSessionResult([], [], [], [])
+    assert.equal(result, '[]')
+  })
+  it('accepts arrays', function () {
+    var result = getSessionResult([1], [], [], [2], [])
+    assert.equal(result, '[1,2]')
+  })
+  it('accepts all weird things', function () {
+    var result = getSessionResult([], [1], [2], [], [], 3, 4, [])
+    var result2 = getSessionResult([], [1], [2], [], [], 3, 4, [], [])
+    var result3 = getSessionResult([], [], [1], [2], [], [], 3, 4, [], [])
+    var result4 = getSessionResult([1], [2], [], [], 3, 4, [], [])
+    var result5 = getSessionResult([1, 2, 3, 4])
+    assert.equal(result, '[1,2,3,4]')
+    assert.equal(result2, '[1,2,3,4]')
+    assert.equal(result3, '[1,2,3,4]')
+    assert.equal(result4, '[1,2,3,4]')
+    assert.equal(result5, '[1,2,3,4]')
+  })
+})


### PR DESCRIPTION
### Description

Revised the `stream_array` function to account for empty arrays as data inputs.
I reverted to adding commas before the item, so I can check if the comma is actually needed.

It was generating invalid JSON.

closes #336 

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
