### PR TITLE
Non-latin text should not be HTML encoded automatically with `@html` selector

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,7 +213,7 @@ function Request (crawler) {
 
 function load (html, url) {
   html = html || ''
-  var $ = html.html ? html : cheerio.load(html)
+  var $ = html.html ? html : cheerio.load(html, { decodeEntities: false })
   if (url) $ = absolutes(url, $)
   return $
 }

--- a/test/xray_spec.js
+++ b/test/xray_spec.js
@@ -372,6 +372,16 @@ describe('Xray basics', function () {
     })
   })
 
+  it('it should not decode non-latin HTML automatically when using `@html` selector', function (done) {
+    var x = Xray()
+
+    x('<div>你好</div>', 'div@html')(function (err, result) {
+      assert.ifError(err)
+      assert.equal(result, '你好')
+      done()
+    })
+  })
+
   describe('.format()', function () {
     xit('should support adding formatters', function () {
       // TODO

--- a/test/xray_spec.js
+++ b/test/xray_spec.js
@@ -372,7 +372,7 @@ describe('Xray basics', function () {
     })
   })
 
-  it('it should not decode non-latin HTML automatically when using `@html` selector', function (done) {
+  it('it should not encode non-latin HTML automatically when using `@html` selector', function (done) {
     var x = Xray()
 
     x('<div>你好</div>', 'div@html')(function (err, result) {


### PR DESCRIPTION
### Description

When loading an html string, html entities shouldn't be automatically HTML encoded.
For example,
```js
const Xray = require('x-ray');
const x = Xray();

x('<div>你好</div>', 'div@html')
  .then(res => console.log(res));
```
The code above outputs `&#x4F60;&#x597D;` instead of `你好`, which doesn't make sense. This issue makes it hard to fetch the real html code from non-latin web pages.

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary