### PR TITLE
Added examples of crawler methods

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -170,6 +170,7 @@ If only `from` is specified, delay exactly `from` milliseconds.
 ```js
 var x = Xray().delay('1s', '10s')
 ```
+.throttle(5, '1s')
 
 ### xray.concurrency(n)
 
@@ -181,6 +182,9 @@ var x = Xray().concurrency(2)
 ### xray.throttle(n, ms)
 
 Throttle the requests to `n` requests per `ms` milliseconds.
+```js
+var x = Xray().throttle(2, '1s')
+```
 
 ### xray.timeout (ms)
 

--- a/Readme.md
+++ b/Readme.md
@@ -170,7 +170,6 @@ If only `from` is specified, delay exactly `from` milliseconds.
 ```js
 var x = Xray().delay('1s', '10s')
 ```
-.throttle(5, '1s')
 
 ### xray.concurrency(n)
 


### PR DESCRIPTION
### Description

Updated readme with examples of `xray.delay()`, `xray.throttle()`, `xray.concurrency()`, and `xray.timeout()` to clarify that they should be called on the initial `xray()` object.